### PR TITLE
fix: nix build failure in nightly update (gemini)

### DIFF
--- a/gemini-cli.nix
+++ b/gemini-cli.nix
@@ -16,7 +16,7 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "gemini-cli";
-  version = "0.41.0";
+  version = "0.42.0";
 
   src = fetchFromGitHub {
     owner = "google-gemini";

--- a/gemini-cli.nix
+++ b/gemini-cli.nix
@@ -49,8 +49,6 @@ buildNpmPackage (finalAttrs: {
   '';
 
   postPatch = ''
-    #simulated failure
-    exit 1 
     # Remove node-pty dependency from package.json
     ${jq}/bin/jq 'del(.optionalDependencies."node-pty")' package.json > package.json.tmp && mv package.json.tmp package.json
 


### PR DESCRIPTION
Removed simulated failure in gemini-cli.nix. Relevant build error: exit 1 in postPatch.




> [!WARNING]
> <details>
> <summary>Firewall blocked 1 domain</summary>
>
> The following domain was blocked by the firewall during workflow execution:
>
> - `localhost`
>> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "localhost"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>


> Generated by [Fix Build Failure Gemini](https://github.com/jtliang24/personal-nix-repo/actions/runs/26064320291) · [◷](https://github.com/search?q=repo%3Ajtliang24%2Fpersonal-nix-repo+%22gh-aw-workflow-id%3A+fix-build-failure-gemini%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Fix Build Failure Gemini, engine: gemini, model: auto, id: 26064320291, workflow_id: fix-build-failure-gemini, run: https://github.com/jtliang24/personal-nix-repo/actions/runs/26064320291 -->

<!-- gh-aw-workflow-id: fix-build-failure-gemini -->